### PR TITLE
Improve torrent fetch stability

### DIFF
--- a/torrent/Constants.h
+++ b/torrent/Constants.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <array>
+#include <string>
+
+namespace torrent {
+    namespace constants {
+        // Extension used for torrent files
+        inline const wchar_t* TORRENT_EXT = L".torrent";
+
+        // User agent string for libtorrent
+        inline const char* TORRENT_USER_AGENT = "TorSync/1.0";
+
+        // Default trackers used when fetching torrents by info hash
+        inline const std::array<std::string, 3> DEFAULT_TRACKERS{
+            "udp://tracker.opentrackr.org:1337/announce",
+            "udp://open.stealth.si:80/announce",
+            "udp://tracker.openbittorrent.com:6969/announce"
+        };
+    }
+}

--- a/torrent/TorSync.cpp
+++ b/torrent/TorSync.cpp
@@ -128,6 +128,9 @@ bool TorSync::Serve(const std::wstring& path, const std::wstring& torrentPath, s
 
     atp.save_path = utils::converters::from_u8string(parentPath.generic_u8string());
     atp.flags |= lt::torrent_flags::seed_mode;
+    atp.trackers.insert(atp.trackers.end(),
+        constants::DEFAULT_TRACKERS.begin(),
+        constants::DEFAULT_TRACKERS.end());
 
     _handle = _session->add_torrent(atp, ec);
 
@@ -179,6 +182,9 @@ bool TorSync::ServeTorrent(const std::wstring& torrentPath, const std::wstring& 
 
     atp.save_path = utils::converters::from_u8string(dp.parent_path().generic_u8string());
     atp.flags |= lt::torrent_flags::seed_mode;
+    atp.trackers.insert(atp.trackers.end(),
+        constants::DEFAULT_TRACKERS.begin(),
+        constants::DEFAULT_TRACKERS.end());
 
     _handle = _session->add_torrent(atp, ec);
 
@@ -234,6 +240,9 @@ bool TorSync::Fetch(const std::string& hash, const std::wstring& dest)
 
     lt::add_torrent_params atp;
     atp.info_hashes.v1 = h.value();
+    atp.trackers.insert(atp.trackers.end(),
+        constants::DEFAULT_TRACKERS.begin(),
+        constants::DEFAULT_TRACKERS.end());
 
     std::filesystem::path fetchPath = std::filesystem::absolute(dest);
     std::error_code ec;
@@ -276,6 +285,8 @@ bool TorSync::Fetch(const std::string& hash, const std::wstring& dest)
     }
 
     SetHash(hash);
+    _handle.force_dht_announce();
+    _handle.force_reannounce();
     PLOGI << "Fetching hash = " << hash << " dest = " << dest << "...";
 
     return true;

--- a/torrent/TorSyncSessionPool.cpp
+++ b/torrent/TorSyncSessionPool.cpp
@@ -57,9 +57,9 @@ TorSyncSessionPool::TorSyncSessionPool(const InitData& idata)
     settings.set_int(lt::settings_pack::seed_choking_algorithm, lt::settings_pack::round_robin);
     settings.set_bool(lt::settings_pack::enable_outgoing_utp, true); // Disable uTP
     settings.set_bool(lt::settings_pack::enable_incoming_utp, true); // Disable uTP
-    settings.set_int(lt::settings_pack::request_timeout, 10); // seconds
-    settings.set_int(lt::settings_pack::piece_timeout, 5); // seconds
-    settings.set_int(lt::settings_pack::peer_timeout, 30); // seconds
+    settings.set_int(lt::settings_pack::request_timeout, 20); // seconds
+    settings.set_int(lt::settings_pack::piece_timeout, 10); // seconds
+    settings.set_int(lt::settings_pack::peer_timeout, 60); // seconds
     settings.set_int(lt::settings_pack::request_queue_time, 5); // seconds
     settings.set_int(lt::settings_pack::max_out_request_queue, 1500);
     settings.set_int(lt::settings_pack::max_allowed_in_request_queue, 4000);


### PR DESCRIPTION
## Summary
- introduce `Constants.h` with user agent, extension and default trackers
- fall back to default trackers when serving or fetching
- force DHT and tracker announces after adding a torrent
- relax libtorrent timeouts for better stability

## Testing
- `g++ -std=c++17 -c main.cpp` *(fails: libtorrent headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863b04977c4832aa70e126a868ed95b