### PR TITLE
Improve peer discovery

### DIFF
--- a/torrent/TorSyncSessionPool.cpp
+++ b/torrent/TorSyncSessionPool.cpp
@@ -158,7 +158,15 @@ void TorSyncSessionPool::Worker()
                         }
                         else
                         {
-                            PLOGI << "Num peers " << torSync->_handle.status().num_peers;
+                            int peers = torSync->_handle.status().num_peers;
+                            PLOGI << "Num peers " << peers;
+
+                            if (peers == 0 && status.state != lt::torrent_status::finished &&
+                                status.state != lt::torrent_status::seeding)
+                            {
+                                torSync->_handle.force_dht_announce();
+                                torSync->_handle.force_reannounce();
+                            }
 
                             if (torSync->GetState() == status.state) continue;
 


### PR DESCRIPTION
## Summary
- bump peer discovery by reannouncing when there are no peers

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6863b343e880832a9e69747eb8e29db9