### PR TITLE
Improve metadata reliability

### DIFF
--- a/torrent/Constants.h
+++ b/torrent/Constants.h
@@ -12,10 +12,25 @@ namespace torrent {
         inline const char* TORRENT_USER_AGENT = "TorSync/1.0";
 
         // Default trackers used when fetching torrents by info hash
-        inline const std::array<std::string, 3> DEFAULT_TRACKERS{
+        inline const std::array<std::string, 10> DEFAULT_TRACKERS{
             "udp://tracker.opentrackr.org:1337/announce",
             "udp://open.stealth.si:80/announce",
-            "udp://tracker.openbittorrent.com:6969/announce"
+            "udp://tracker.openbittorrent.com:6969/announce",
+            "udp://p4p.arenabg.com:1337/announce",
+            "udp://p4p.arenabg.ch:1337/announce",
+            "udp://tracker.torrent.eu.org:451/announce",
+            "http://tracker.opentrackr.org:1337/announce",
+            "http://open.stealth.si:80/announce",
+            "http://tracker.openbittorrent.com:6969/announce",
+            "udp://tracker.leechers-paradise.org:6969/announce"
+        };
+
+        // Default DHT routers to improve metadata lookup
+        inline const std::array<std::pair<std::string, int>, 4> DEFAULT_DHT_ROUTERS{
+            std::pair{"router.bittorrent.com", 6881},
+            std::pair{"dht.transmissionbt.com", 6881},
+            std::pair{"router.utorrent.com", 6881},
+            std::pair{"router.bt.ouinet.work", 6881}
         };
     }
 }

--- a/torrent/TorSyncSessionPool.cpp
+++ b/torrent/TorSyncSessionPool.cpp
@@ -40,7 +40,8 @@ TorSyncSessionPool::TorSyncSessionPool(const InitData& idata)
     settings.set_int(lt::settings_pack::active_downloads, -1);
     settings.set_int(lt::settings_pack::active_seeds, -1);
     settings.set_int(lt::settings_pack::dht_announce_interval, 10);
-    settings.set_str(lt::settings_pack::dht_bootstrap_nodes, "router.bittorrent.com:6881,dht.transmissionbt.com:6881,router.bt.ouinet.work:6881,router.utorrent.com,router.bittorrent.com:6881");
+    settings.set_str(lt::settings_pack::dht_bootstrap_nodes,
+        "router.bittorrent.com:6881,dht.transmissionbt.com:6881,router.bt.ouinet.work:6881,router.utorrent.com:6881");
 
     settings.set_int(lt::settings_pack::local_service_announce_interval, 10);
     settings.set_bool(lt::settings_pack::close_redundant_connections, false);
@@ -76,6 +77,15 @@ TorSyncSessionPool::TorSyncSessionPool(const InitData& idata)
     lt::session_params params(settings);
 
     _session = std::make_shared<lt::session>(params);
+
+    if (_idata.global)
+    {
+        _session->start_dht();
+        for (const auto& [host, port] : constants::DEFAULT_DHT_ROUTERS)
+        {
+            _session->add_dht_router(host.c_str(), port);
+        }
+    }
     _worker = std::thread{ &TorSyncSessionPool::Worker, this };
 }
 


### PR DESCRIPTION
## Summary
- expand default tracker list
- add default DHT routers and configure session to use them

## Testing
- `g++ -std=c++20 main.cpp torrent/TorSyncSessionPool.cpp torrent/TorSyncManager.cpp torrent/TorSync.cpp -I torrent -lpthread -ltorrent-rasterbar -o torrentee` *(fails: `plog/Log.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc6552c8832aaf496f6a70dee6ad