### PR TITLE
Fix Selenium Chrome driver initialization

### DIFF
--- a/parse_vkusvill_selenium.py
+++ b/parse_vkusvill_selenium.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -22,7 +23,8 @@ def setup_driver() -> webdriver.Chrome:
     options.add_argument("--headless=new")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
-    driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
+    service = Service(ChromeDriverManager().install())
+    driver = webdriver.Chrome(service=service, options=options)
     return driver
 
 


### PR DESCRIPTION
## Summary
- fix webdriver initialization for Selenium 4

## Testing
- `python parse_vkusvill_selenium.py` *(fails to download Chrome driver: Could not reach host)*

------
https://chatgpt.com/codex/tasks/task_e_686a53bbc210832a99b76b1ca86f5d57